### PR TITLE
feat: 深掘り結果を配列管理し個別セクション表示

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -384,13 +384,21 @@ export default function App() {
                                 </div>
 
                                 {/* Deep dive output */}
-                                {results.deepDive && (
-                                    <div className={`${T.card} p-5 border-l-2 border-l-blue-400 dark:border-l-blue-600`}>
-                                        <h4 className={`text-xs font-semibold ${T.accentTxt} mb-2 flex items-center gap-1`}>
-                                            <Search className='w-3.5 h-3.5' />
-                                            深掘り分析
-                                        </h4>
-                                        <RichText text={results.deepDive} />
+                                {results.deepDives && results.deepDives.length > 0 && (
+                                    <div className='space-y-3'>
+                                        <div className='flex items-center justify-between'>
+                                            <h4 className={`text-xs font-semibold ${T.accentTxt} flex items-center gap-1`}>
+                                                <Search className='w-3.5 h-3.5' />
+                                                深掘り分析（{results.deepDives.length}件）
+                                            </h4>
+                                            <button onClick={() => setResults(p => p ? { ...p, deepDives: [] } : p)} className={`text-xs ${T.t3} hover:text-red-500 transition`}>クリア</button>
+                                        </div>
+                                        {results.deepDives.map((dd, i) => (
+                                            <div key={i} className={`${T.card} p-5 border-l-2 border-l-blue-400 dark:border-l-blue-600`}>
+                                                <p className={`text-xs font-semibold ${T.t1} mb-2`}>{dd.question}</p>
+                                                <RichText text={dd.answer} />
+                                            </div>
+                                        ))}
                                     </div>
                                 )}
 

--- a/src/hooks/useAI.ts
+++ b/src/hooks/useAI.ts
@@ -323,11 +323,10 @@ ${commonConditions}。
         ? await callAIWithKey(apiKey.trim(), modelId, [msg], 4096)
         : await callAI(modelId, [msg], 2000);
 
-      setResults(p => p ? ({ ...p, deepDive: (p.deepDive ? p.deepDive + '\n\n---\n\n' : '') + `### ${q}\n\n${raw}` }) : p);
+      setResults(p => p ? ({ ...p, deepDives: [...(p.deepDives || []), { question: q, answer: raw }] }) : p);
     } catch {
-      // APIコール失敗時: seedデータのコンテキストからフォールバック回答を生成
       const fallback = buildFallbackDeepDive(q, results);
-      setResults(p => p ? ({ ...p, deepDive: (p.deepDive ? p.deepDive + '\n\n---\n\n' : '') + `### ${q}\n\n${fallback}` }) : p);
+      setResults(p => p ? ({ ...p, deepDives: [...(p.deepDives || []), { question: q, answer: fallback }] }) : p);
     }
     setDiving(false);
   }, [results, modelId]);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,11 +32,17 @@ export interface Idea {
   impact: Impact;
 }
 
+export interface DeepDiveEntry {
+  question: string;
+  answer: string;
+}
+
 export interface AIResults {
   understanding: string;
   ideas: Idea[];
   suggestions?: string[]; // AI生成の文脈に即した深掘り質問
   deepDive?: string;
+  deepDives?: DeepDiveEntry[];
   refinement?: string;
 }
 

--- a/src/utils/report.ts
+++ b/src/utils/report.ts
@@ -46,7 +46,12 @@ export const buildReportMd = (
     md += `---\n\n## ブラッシュアップ\n\n${results.refinement}\n`;
   }
   
-  if (results.deepDive) {
+  if (results.deepDives?.length) {
+    md += `---\n\n## 深掘り\n\n`;
+    results.deepDives.forEach((dd, i) => {
+      md += `### ${i + 1}. ${dd.question}\n\n${dd.answer}\n\n`;
+    });
+  } else if (results.deepDive) {
     md += `---\n\n## 深掘り\n\n${results.deepDive}\n`;
   }
   


### PR DESCRIPTION
## Summary
- deepDiveを文字列連結から`DeepDiveEntry[]`配列管理に変更
- 各深掘りをquestion/answer付きの個別カードで表示
- クリアボタン追加
- レポート出力も配列形式に対応（旧deepDive文字列との後方互換あり）

Closes #12