### PR TITLE
feat: フォーム必須項目バリデーション追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,6 +107,7 @@ export default function App() {
     // Local UI state
     const [showCfg, setShowCfg] = useState(false)
     const [showPrev, setShowPrev] = useState(false)
+    const [showValidation, setShowValidation] = useState(false)
     const [seedOpen, setSeedOpen] = useState(false)
     const seedTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
     const seedRef = useRef<HTMLDivElement | null>(null)
@@ -129,6 +130,11 @@ export default function App() {
         : null
 
     const handleGenerate = () => {
+        if (!form.productService.trim() || !form.teamGoals.trim()) {
+            setShowValidation(true)
+            return
+        }
+        setShowValidation(false)
         const pn = getValidProjectName()
         setUsedName(pn)
         generate(pn, form, dep, sesLabel, tlStr, issueStr, (res, prompt) => {
@@ -273,6 +279,7 @@ export default function App() {
                                 dep={dep}
                                 setDep={setDep}
                                 proMode={proMode}
+                                showValidation={showValidation}
                             />
 
                             {/* Error */}

--- a/src/components/form/ProjectForm.tsx
+++ b/src/components/form/ProjectForm.tsx
@@ -29,6 +29,7 @@ interface ProjectFormProps {
     dep: number
     setDep: (d: number) => void
     proMode: boolean
+    showValidation?: boolean
 }
 
 export const ProjectForm: React.FC<ProjectFormProps> = ({
@@ -37,6 +38,7 @@ export const ProjectForm: React.FC<ProjectFormProps> = ({
     dep,
     setDep,
     proMode,
+    showValidation = false,
 }) => {
     const depTable = proMode ? PRO_DEPTH : FREE_DEPTH
     const [issueTemplateOpen, setIssueTemplateOpen] = useState(false)
@@ -171,7 +173,7 @@ export const ProjectForm: React.FC<ProjectFormProps> = ({
                         value={form.productService}
                         onChange={onF}
                         placeholder='プロダクト / サービスカテゴリ名'
-                        className={T.inp}
+                        className={`${T.inp} ${showValidation && !form.productService.trim() ? 'ring-2 ring-red-400 dark:ring-red-500' : ''}`}
                     />
                     {form.productService === '' && (
                         <div className='flex flex-wrap gap-1 mt-1'>
@@ -314,7 +316,7 @@ export const ProjectForm: React.FC<ProjectFormProps> = ({
                         onChange={onF}
                         rows={2}
                         placeholder='定量目標を含めると精度向上（下から選択 or 自由入力）'
-                        className={`${T.inp} resize-none`}
+                        className={`${T.inp} resize-none ${showValidation && !form.teamGoals.trim() ? 'ring-2 ring-red-400 dark:ring-red-500' : ''}`}
                     />
                     <div className='relative mt-1'>
                         <button


### PR DESCRIPTION
## Summary
- 生成ボタン押下時にproductService/teamGoalsが空なら赤枠でフィードバック
- 入力開始で赤枠が解除される
- useAI側の既存チェックと二重防御

Closes #13