### PR TITLE
feat: Proモードでも接続テストを有効化

### DIFF
--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -12,7 +12,7 @@ interface SettingsModalProps {
         status: 'idle' | 'testing' | 'ok' | 'error'
         msg: string
     }) => void
-    runConnTest: () => void
+    runConnTest: (apiKey?: string) => void
     apiKey: string
     setApiKey: (key: string) => void
 }
@@ -142,46 +142,44 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                     </div>
                 </div>
 
-                {/* Connection test (only relevant in free mode via proxy) */}
-                {!proMode && (
-                    <div className={`flex items-center gap-2 pt-2 border-t ${T.div}`}>
-                        <button
-                            onClick={runConnTest}
-                            disabled={connStatus.status === 'testing'}
-                            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg border text-xs font-medium ${T.btnGhost} disabled:opacity-40`}
+                {/* Connection test */}
+                <div className={`flex items-center gap-2 pt-2 border-t ${T.div}`}>
+                    <button
+                        onClick={() => runConnTest(apiKey)}
+                        disabled={connStatus.status === 'testing'}
+                        className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg border text-xs font-medium ${T.btnGhost} disabled:opacity-40`}
+                    >
+                        {connStatus.status === 'testing' ? (
+                            <>
+                                <Loader className='w-3 h-3 animate-spin' />
+                                テスト中…
+                            </>
+                        ) : (
+                            <>
+                                <Wifi className='w-3 h-3' />
+                                接続テスト
+                            </>
+                        )}
+                    </button>
+                    {connStatus.status === 'ok' && (
+                        <span className='flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400'>
+                            <span className='w-1.5 h-1.5 rounded-full bg-emerald-500' />
+                            {connStatus.msg}
+                        </span>
+                    )}
+                    {connStatus.status === 'error' && (
+                        <span
+                            className='flex items-center gap-1 text-xs text-red-600 dark:text-red-400 max-w-xs truncate'
+                            title={connStatus.msg}
                         >
-                            {connStatus.status === 'testing' ? (
-                                <>
-                                    <Loader className='w-3 h-3 animate-spin' />
-                                    テスト中…
-                                </>
-                            ) : (
-                                <>
-                                    <Wifi className='w-3 h-3' />
-                                    接続テスト
-                                </>
-                            )}
-                        </button>
-                        {connStatus.status === 'ok' && (
-                            <span className='flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400'>
-                                <span className='w-1.5 h-1.5 rounded-full bg-emerald-500' />
-                                {connStatus.msg}
-                            </span>
-                        )}
-                        {connStatus.status === 'error' && (
-                            <span
-                                className='flex items-center gap-1 text-xs text-red-600 dark:text-red-400 max-w-xs truncate'
-                                title={connStatus.msg}
-                            >
-                                <WifiOff className='w-3 h-3 shrink-0' />
-                                {connStatus.msg}
-                            </span>
-                        )}
-                        <p className={`ml-auto text-xs ${T.t3}`}>
-                            サーバープロキシ経由
-                        </p>
-                    </div>
-                )}
+                            <WifiOff className='w-3 h-3 shrink-0' />
+                            {connStatus.msg}
+                        </span>
+                    )}
+                    <p className={`ml-auto text-xs ${T.t3}`}>
+                        {proMode ? 'OpenAI直接接続' : 'サーバープロキシ経由'}
+                    </p>
+                </div>
             </div>
 
             {showHelp && <HelpModal onClose={() => setShowHelp(false)} />}

--- a/src/constants/models.ts
+++ b/src/constants/models.ts
@@ -16,12 +16,16 @@ export const MODELS: ModelInfo[] = [
   { id: 'gpt-4.1-nano', label: '4.1 Nano', t: '最安',    cost: '$'  },
 ];
 
-export const testConn = async (modelId: string): Promise<string> => {
+export const testConn = async (modelId: string, apiKey = ''): Promise<string> => {
   const usesCompletionTokens = modelId.startsWith('gpt-5') || modelId.startsWith('o');
   const tokenParam = usesCompletionTokens ? { max_completion_tokens: 100 } : { max_tokens: 100 };
-  const r = await fetch('/api/openai/v1/chat/completions', {
+  const proMode = apiKey.trim().startsWith('sk-');
+  const url = proMode ? 'https://api.openai.com/v1/chat/completions' : '/api/openai/v1/chat/completions';
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (proMode) headers['Authorization'] = `Bearer ${apiKey.trim()}`;
+  const r = await fetch(url, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers,
     body: JSON.stringify({ model: modelId, ...tokenParam, messages: [{ role: 'user', content: 'Say exactly: OK' }] }),
   });
   const d = await r.json();

--- a/src/hooks/useAI.ts
+++ b/src/hooks/useAI.ts
@@ -60,10 +60,10 @@ export const useAI = () => {
   const [diving, setDiving] = useState(false);
   const [hist, setHist] = useState<any[]>([]);
 
-  const runConnTest = useCallback(async () => {
+  const runConnTest = useCallback(async (apiKey = '') => {
     setConnStatus({ status: 'testing', msg: '' });
     try {
-      const model = await testConn(modelId);
+      const model = await testConn(modelId, apiKey);
       setConnStatus({ status: 'ok', msg: `OK: ${model}` });
     } catch (e: any) {
       setConnStatus({ status: 'error', msg: e.message });


### PR DESCRIPTION
## Summary
- 接続テストがFree/Pro両モードで利用可能に
- Pro時はOpenAI直接接続、Free時はプロキシ経由を表示
- testConn関数にapiKeyパラメータ追加

Closes #14