### PR TITLE
fix: Free mode JSON生成失敗を修正

### DIFF
--- a/src/constants/models.ts
+++ b/src/constants/models.ts
@@ -52,7 +52,11 @@ export const callAI = async (modelId: string, msgs: any[], maxTokens = 4096, jso
   });
   if (!r.ok) throw new Error(friendlyError(r.status, (await r.text()).slice(0, 300)));
   const data = await r.json();
-  return data.choices?.[0]?.message?.content || '';
+  const content = data.choices?.[0]?.message?.content || '';
+  if (!content && data.choices?.[0]?.finish_reason === 'length') {
+    throw new Error('回答が長すぎてトークン上限に達しました。分析深度を下げるか、入力を簡潔にしてください。');
+  }
+  return content;
 };
 
 /** Pro mode: call OpenAI directly with user's own API key */
@@ -69,5 +73,9 @@ export const callAIWithKey = async (apiKey: string, modelId: string, msgs: any[]
   });
   if (!r.ok) throw new Error(friendlyError(r.status, (await r.text()).slice(0, 300)));
   const data = await r.json();
-  return data.choices?.[0]?.message?.content || '';
+  const content = data.choices?.[0]?.message?.content || '';
+  if (!content && data.choices?.[0]?.finish_reason === 'length') {
+    throw new Error('回答が長すぎてトークン上限に達しました。分析深度を下げるか、入力を簡潔にしてください。');
+  }
+  return content;
 };

--- a/src/constants/prompts.ts
+++ b/src/constants/prompts.ts
@@ -90,9 +90,9 @@ export function getSubIssueSuggestions(parentText: string): string[] {
 
 // Free mode (no API key) — limited tiers
 export const FREE_DEPTH: Record<number, { label: string; desc: string; ideas: number; wait: string; maxTokens: number }> = {
-  1: { label: 'Lite',     desc: '速報',    ideas: 3, wait: '1-2分',  maxTokens: 800  },
-  2: { label: 'Standard', desc: '標準',    ideas: 5, wait: '3-5分',  maxTokens: 1500 },
-  3: { label: 'Deep',     desc: '詳細',    ideas: 7, wait: '5-10分', maxTokens: 2500 },
+  1: { label: 'Lite',     desc: '速報',    ideas: 3, wait: '〜1分',  maxTokens: 4096  },
+  2: { label: 'Standard', desc: '標準',    ideas: 5, wait: '1-3分',  maxTokens: 8000 },
+  3: { label: 'Deep',     desc: '詳細',    ideas: 7, wait: '3-5分', maxTokens: 8000 },
 };
 
 // Pro mode (user's own API key) — full tiers

--- a/src/hooks/useAI.ts
+++ b/src/hooks/useAI.ts
@@ -177,18 +177,10 @@ ${rd.lens}
 【出力形式】JSONのみ・コードブロック不要:
 {"understanding":"${dmap.understanding}","ideas":[${dc.ideas}個: {"title":"8語以内の行動起点タイトル","description":"${dmap.desc}","priority":"High/Medium/Low","effort":"Low/Medium/High","impact":"Low/Medium/High"}],"suggestions":["入力内容のプロダクト・課題・目標に直結する深掘り質問を5個。セッションタイプに縛られず実務担当者が次に考えるべき問いを設定すること"]}`;
     } else {
-      return `【あなたの役割】
-${rd.role}
-
-【前提条件】
-${commonConditions}。
-
-【分析対象】
-プロダクト・サービス: ${form.productService} / 目標: ${form.teamGoals}${issueStr ? ` / 課題: ${issueStr}` : ''}
-セッション: ${sesLabel}
-
-【出力形式】JSONのみ・コードブロック不要:
-{"understanding":"${dmap.understanding}","ideas":[${dc.ideas}個: {"title":"6語以内","description":"${dmap.desc}","priority":"High/Medium/Low","effort":"Low/Medium/High","impact":"Low/Medium/High"}],"suggestions":["入力内容に直結する深掘り質問を4個"]}`;
+      return `ビジネスコンサルとして建設的に分析。${rd.lens}の観点。
+対象: ${form.productService} / 目標: ${form.teamGoals}${issueStr ? ` / 課題: ${issueStr}` : ''}
+JSONのみ回答:
+{"understanding":"${dmap.understanding}","ideas":[${dc.ideas}個: {"title":"6語以内","description":"${dmap.desc}","priority":"High/Medium/Low","effort":"Low/Medium/High","impact":"Low/Medium/High"}],"suggestions":["深掘り質問を4個"]}`;
     }
   };
 
@@ -223,7 +215,7 @@ ${commonConditions}。
       const msg = { role: 'user', content: prompt };
       const raw = proMode
         ? await callAIWithKey(apiKey.trim(), modelId, [msg], dc.maxTokens, true)
-        : await callAI(modelId, [msg], dc.maxTokens, true);
+        : await callAI(modelId, [msg], dc.maxTokens, false);
       const parsed = parseAIJson(raw);
       
       setResults(parsed);


### PR DESCRIPTION
## Summary
- Free mode の maxTokens を 800/1500/2500 → 4096/8000/8000 に引き上げ
- Free mode では JSON mode を無効化（gpt-5-nano互換性）
- Free mode プロンプトを圧縮してトークン消費を削減
- callAI/callAIWithKey に finish_reason=length 時のエラーハンドリング追加

## Root Cause
gpt-5-nano が max_completion_tokens 不足時に空レスポンス (`""`) + `finish_reason: "length"` を返し、parseAIJson が "No JSON object found" エラーになっていた

Closes #22-related