### PR TITLE
feat: 左右パネルのドラッグリサイズ + プリセットレイアウト

### DIFF
--- a/src/hooks/usePanelResize.ts
+++ b/src/hooks/usePanelResize.ts
@@ -1,0 +1,65 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+
+const STORAGE_KEY = 'panelRatio';
+const MIN = 20;
+const MAX = 80;
+const DEFAULT = 40;
+
+export const PRESETS = {
+  leftFocus:  70,
+  equal:      50,
+  rightFocus: 30,
+} as const;
+
+export function usePanelResize() {
+  const [ratio, setRatio] = useState(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    return saved ? Math.max(MIN, Math.min(MAX, Number(saved))) : DEFAULT;
+  });
+  const [isDragging, setIsDragging] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const applyRatio = useCallback((r: number) => {
+    const clamped = Math.max(MIN, Math.min(MAX, Math.round(r)));
+    setRatio(clamped);
+    localStorage.setItem(STORAGE_KEY, String(clamped));
+  }, []);
+
+  const startDrag = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isDragging) return;
+
+    const onMove = (e: MouseEvent) => {
+      const container = containerRef.current;
+      if (!container) return;
+      const rect = container.getBoundingClientRect();
+      const pct = ((e.clientX - rect.left) / rect.width) * 100;
+      applyRatio(pct);
+    };
+
+    const onUp = () => setIsDragging(false);
+
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+    // Prevent text selection while dragging
+    document.body.style.userSelect = 'none';
+    document.body.style.cursor = 'col-resize';
+
+    return () => {
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+      document.body.style.userSelect = '';
+      document.body.style.cursor = '';
+    };
+  }, [isDragging, applyRatio]);
+
+  const activePreset = Object.entries(PRESETS).find(
+    ([, v]) => Math.abs(ratio - v) <= 3
+  )?.[0] as keyof typeof PRESETS | undefined;
+
+  return { ratio, applyRatio, startDrag, isDragging, containerRef, activePreset };
+}


### PR DESCRIPTION
## Summary
- ドラッグハンドル（GripVerticalアイコン）で左右パネル幅を自由に変更
- ヘッダーにプリセット3種のアイコンボタン:
  - PanelLeftClose: 左メイン (70:30)
  - Columns2: 均等 (50:50)
  - PanelRightClose: 右メイン (30:70)
- ratio は localStorage で永続化、リロードしても維持
- ドラッグ中はカーソル変更 + ハンドル青色ハイライト
- min 20% / max 80% にクランプ
- モバイル (lg未満) では従来通り縦並び、リサイズUI非表示

## New files
- `src/hooks/usePanelResize.ts`: リサイズロジック Hook

## Test plan
- [ ] lg以上でドラッグリサイズ動作確認
- [ ] プリセットボタンで即座に切り替わること
- [ ] リロード後にratio復元されること
- [ ] モバイルでは縦並びでリサイズUI非表示