### PR TITLE
refactor: any型排除 + タッチリサイズ + hist制限 + refine後クリア

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,7 +45,7 @@ import { usePanelResize, PRESETS } from './hooks/usePanelResize'
 export default function App() {
     // Global hooks
     const { isDark, toggleTheme } = useTheme()
-    const { ratio, applyRatio, startDrag, isDragging, containerRef, activePreset } = usePanelResize()
+    const { ratio, applyRatio, startDrag, startTouchDrag, isDragging, containerRef, activePreset } = usePanelResize()
 
     const {
         logs,
@@ -226,7 +226,7 @@ export default function App() {
     handleGenerateRef.current = handleGenerate
 
     const handleRefine = () => {
-        refine((res: any, text: string) => {
+        refine((res, text) => {
             if (stgSettings.autoSave)
                 saveLog(usedName, form, res, text, cm.label, dep)
         }, apiKey)
@@ -454,6 +454,7 @@ export default function App() {
                     {/* ── Drag handle ── */}
                     <div
                         onMouseDown={startDrag}
+                        onTouchStart={startTouchDrag}
                         className={`hidden lg:flex items-center justify-center shrink-0 cursor-col-resize group transition-colors self-stretch ${isDragging ? 'w-1.5 bg-blue-500/40' : 'w-4 hover:bg-blue-500/10'}`}
                     >
                         <GripVertical className={`w-3 h-3 transition-colors ${isDragging ? 'text-blue-500' : 'text-slate-300 dark:text-slate-600 group-hover:text-blue-400'}`} />

--- a/src/constants/models.ts
+++ b/src/constants/models.ts
@@ -1,4 +1,4 @@
-import { ModelInfo } from '../types';
+import { ModelInfo, ChatMessage } from '../types';
 
 const friendlyError = (status: number, body: string): string => {
   if (status === 429) return 'APIレート制限に達しました。しばらく待ってから再試行してください。';
@@ -39,7 +39,7 @@ export const testConn = async (modelId: string, apiKey = ''): Promise<string> =>
 };
 
 /** Free mode: call via server proxy (no user key needed) */
-export const callAI = async (modelId: string, msgs: any[], maxTokens = 4096, jsonMode = false): Promise<string> => {
+export const callAI = async (modelId: string, msgs: ChatMessage[], maxTokens = 4096, jsonMode = false): Promise<string> => {
   const usesCompletionTokens = modelId.startsWith('gpt-5') || modelId.startsWith('o');
   const tokenParam = usesCompletionTokens ? { max_completion_tokens: maxTokens } : { max_tokens: maxTokens };
   const r = await fetch(API_PROXY, {
@@ -60,7 +60,7 @@ export const callAI = async (modelId: string, msgs: any[], maxTokens = 4096, jso
 };
 
 /** Pro mode: call OpenAI directly with user's own API key */
-export const callAIWithKey = async (apiKey: string, modelId: string, msgs: any[], maxTokens = 4096, jsonMode = false): Promise<string> => {
+export const callAIWithKey = async (apiKey: string, modelId: string, msgs: ChatMessage[], maxTokens = 4096, jsonMode = false): Promise<string> => {
   const usesCompletionTokens = modelId.startsWith('gpt-5') || modelId.startsWith('o');
   const tokenParam = usesCompletionTokens ? { max_completion_tokens: maxTokens } : { max_tokens: maxTokens };
   const r = await fetch(API_DIRECT, {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -64,6 +64,11 @@ export interface Settings {
   autoSave: boolean;
 }
 
+export interface ChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
 export interface ModelInfo {
   id: string;
   label: string;


### PR DESCRIPTION
## Summary

**型安全性:**
- `ChatMessage` 型を `types/index.ts` に追加
- `callAI` / `callAIWithKey` の `msgs: any[]` → `ChatMessage[]`
- `parseAIJson` の戻り値 `any` → `AIResults`
- `hist` state `any[]` → `ChatMessage[]`
- 全 `catch(e: any)` → `catch(e: unknown)` + `instanceof Error` チェック
- App.tsx の `refine((res: any, ...` → 型推論に委任

**UX修正:**
- パネルリサイズに `touchmove` / `touchend` 対応（タブレット）
- 会話履歴 `hist` を最新10件に制限（メモリリーク防止）
- `refine` 成功後に `reviewText` を自動クリア