### PR TITLE
fix: localStorage quota handling + 型安全化

### DIFF
--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -13,10 +13,13 @@ export const loadLogs = (): LogEntry[] => {
   }
 };
 
-export const saveLogs = (l: LogEntry[]): void => {
+export const saveLogs = (l: LogEntry[]): boolean => {
   try {
     localStorage.setItem(STORE_KEY, JSON.stringify(l));
-  } catch {}
+    return true;
+  } catch {
+    return false;
+  }
 };
 
 export const loadSettings = (): Settings => {
@@ -33,7 +36,7 @@ export const saveSettings = (s: Settings): void => {
   } catch {}
 };
 
-export const exportJSON = (data: any, fn: string): void => {
+export const exportJSON = (data: unknown, fn: string): void => {
   const b = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json;charset=utf-8' });
   const u = URL.createObjectURL(b);
   Object.assign(document.createElement('a'), { href: u, download: fn }).click();


### PR DESCRIPTION
## Summary
- saveLogs の戻り値を boolean に変更し、quota 超過時に警告表示
- importLogs の引数型を any → unknown に変更、型ガード追加
- インポート上限を 200 に統一（保存上限と一致）
- quota 超過時のユーザー通知を追加

## Test plan
- [x] tsc --noEmit pass
- [x] vite build pass
- [ ] ログ保存・インポートが正常動作すること