### PR TITLE
refactor: isProMode ヘルパーでsk-チェック集約

### DIFF
--- a/src/constants/models.ts
+++ b/src/constants/models.ts
@@ -1,5 +1,8 @@
 import { ModelInfo, ChatMessage } from '../types';
 
+/** APIキーがPro mode（ユーザー所有）か判定 */
+export const isProMode = (apiKey: string): boolean => apiKey.trim().startsWith('sk-');
+
 const friendlyError = (status: number, body: string): string => {
   if (status === 429) return 'APIレート制限に達しました。しばらく待ってから再試行してください。';
   if (status === 401) return 'APIキーが無効です。設定を確認してください。';
@@ -24,7 +27,7 @@ export const MODELS: ModelInfo[] = [
 export const testConn = async (modelId: string, apiKey = ''): Promise<string> => {
   const usesCompletionTokens = modelId.startsWith('gpt-5') || modelId.startsWith('o');
   const tokenParam = usesCompletionTokens ? { max_completion_tokens: 100 } : { max_tokens: 100 };
-  const proMode = apiKey.trim().startsWith('sk-');
+  const proMode = isProMode(apiKey);
   const url = proMode ? API_DIRECT : API_PROXY;
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   if (proMode) headers['Authorization'] = `Bearer ${apiKey.trim()}`;

--- a/src/hooks/useAI.ts
+++ b/src/hooks/useAI.ts
@@ -46,7 +46,7 @@ function parseAIJson(raw: string): AIResults {
   return JSON.parse(text);
 }
 import { BrainstormForm, AIResults, ChatMessage } from '../types';
-import { callAI, callAIWithKey, testConn, DEFAULT_MODEL_ID } from '../constants/models';
+import { callAI, callAIWithKey, testConn, DEFAULT_MODEL_ID, isProMode } from '../constants/models';
 import { FREE_DEPTH, PRO_DEPTH } from '../constants/prompts';
 
 export const useAI = () => {
@@ -208,7 +208,7 @@ JSONのみ回答:
       return;
     }
 
-    const proMode = apiKey.trim().startsWith('sk-');
+    const proMode = isProMode(apiKey);
     const depTable = proMode ? PRO_DEPTH : FREE_DEPTH;
     const dc = depTable[dep] || depTable[1];
 
@@ -263,7 +263,7 @@ JSONのみ回答:
     if (!reviewText.trim() || !results) return;
     setRefining(true);
     setError(null);
-    const proMode = apiKey.trim().startsWith('sk-');
+    const proMode = isProMode(apiKey);
 
     try {
       const msg: ChatMessage = { role: 'user', content: `あなたは戦略コンサルタントです。以下のレビュー・フィードバックに基づき、戦略提案をブラッシュアップしてください。\n\n【前提条件】現状を批判せず、強みを活かした建設的な改善提案に絞る。担当者が実行できる具体案を出す。\n\n【レビュー内容】${reviewText}\n\nMarkdown形式（見出し・箇条書き活用）で回答してください。` };
@@ -318,7 +318,7 @@ JSONのみ回答:
     if (!results) return;
     setDiving(true);
     setError(null);
-    const proMode = apiKey.trim().startsWith('sk-');
+    const proMode = isProMode(apiKey);
     const currentResults = results;
 
     try {

--- a/src/hooks/useBrainstormForm.ts
+++ b/src/hooks/useBrainstormForm.ts
@@ -3,6 +3,7 @@ import { BrainstormForm } from '../types';
 import { nextSeed, getSeedByIndex, MOCK_SCENARIOS } from '../constants/mockData';
 import { TYPES, getDeepDiveSuggestions } from '../constants/prompts';
 import { autoN } from '../utils/formatters';
+import { isProMode } from '../constants/models';
 
 const initialFormState: BrainstormForm = {
   projectName: '',
@@ -63,7 +64,7 @@ export const useBrainstormForm = () => {
 
   const applySeed = useCallback((index?: number) => {
     const s = index !== undefined ? getSeedByIndex(index) : nextSeed();
-    const isPro = (localStorage.getItem('userApiKey') || '').trim().startsWith('sk-');
+    const isPro = isProMode(localStorage.getItem('userApiKey') || '');
 
     setSeedModelId(s.modelId);
     setDep(isPro ? s.dep : Math.min(s.dep, 3));


### PR DESCRIPTION
## Summary
- `isProMode(apiKey)` ヘルパーを models.ts に追加
- 5箇所に散在していた `apiKey.trim().startsWith('sk-')` を統一
- 変更対象: models.ts, useAI.ts, useBrainstormForm.ts

## Test plan
- [x] tsc --noEmit pass
- [x] vite build pass
- [ ] Free/Pro 両モードで動作確認