### PR TITLE
refactor: 型安全強化 + デッドコード削除 + modal a11y

### DIFF
--- a/src/components/layout/HeaderBar.tsx
+++ b/src/components/layout/HeaderBar.tsx
@@ -11,13 +11,14 @@ import {
     Columns2,
     PanelRightClose,
 } from 'lucide-react'
+import { ConnStatus } from '../../types'
 import { T } from '../../constants/theme'
 import { PRESETS } from '../../hooks/usePanelResize'
 
 interface HeaderBarProps {
     proMode: boolean
     modelLabel: string
-    connStatus: { status: 'idle' | 'testing' | 'ok' | 'error'; msg: string }
+    connStatus: ConnStatus
     seedScenarios: Array<{ label: string; form: { productService: string } }>
     onSeed: (index: number) => void
     activePreset?: keyof typeof PRESETS

--- a/src/components/modals/LogPanel.tsx
+++ b/src/components/modals/LogPanel.tsx
@@ -11,7 +11,7 @@ interface LogPanelProps {
   onExportAll: () => void;
   onExportAnswers: () => void;
   onExportOne: (log: LogEntry) => void;
-  onImport: (data: any) => void;
+  onImport: (data: unknown) => void;
   settings: AppSettings;
   onSettings: (s: AppSettings) => void;
 }
@@ -41,12 +41,12 @@ export const LogPanel: React.FC<LogPanelProps> = ({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-3 bg-black/50 backdrop-blur-sm" onClick={onClose}>
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-3 bg-black/50 backdrop-blur-sm" onClick={onClose} role="dialog" aria-modal="true" aria-labelledby="log-panel-title">
       <div className={`${T.card} w-full max-w-2xl max-h-[90vh] flex flex-col shadow-2xl`} onClick={e => e.stopPropagation()}>
         <div className={`flex items-center justify-between px-4 py-2.5 border-b ${T.div} shrink-0`}>
           <div className="flex items-center gap-2">
             <Database className="w-4 h-4 text-blue-500" />
-            <span className={`text-sm font-semibold ${T.t1}`}>ログ管理</span>
+            <span id="log-panel-title" className={`text-sm font-semibold ${T.t1}`}>ログ管理</span>
             <span className={`text-xs ${T.t3}`}>{logs.length}件</span>
           </div>
           <button onClick={onClose} className={`p-1 rounded-lg ${T.btnGhost}`}>

--- a/src/components/modals/PreviewModal.tsx
+++ b/src/components/modals/PreviewModal.tsx
@@ -45,6 +45,9 @@ export const PreviewModal: React.FC<PreviewProps> = ({ md, pn, onClose }) => {
         <div
             className='fixed inset-0 z-50 flex items-center justify-center p-3 bg-black/50 backdrop-blur-sm'
             onClick={onClose}
+            role="dialog"
+            aria-modal="true"
+            aria-label="レポートプレビュー"
         >
             <div
                 className={`${T.card} w-full max-w-3xl max-h-[90vh] flex flex-col shadow-2xl overflow-hidden`}

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -1,17 +1,15 @@
 import React, { useState } from 'react'
 import { Wifi, WifiOff, Loader, Key, Zap, HelpCircle, Eye, EyeOff, X } from 'lucide-react'
 import { MODELS, isProMode } from '../../constants/models'
+import { ConnStatus } from '../../types'
 import { T } from '../../constants/theme'
 import { HelpModal } from './HelpModal'
 
 interface SettingsModalProps {
     modelId: string
     setModelId: (id: string) => void
-    connStatus: { status: 'idle' | 'testing' | 'ok' | 'error'; msg: string }
-    setConnStatus: (status: {
-        status: 'idle' | 'testing' | 'ok' | 'error'
-        msg: string
-    }) => void
+    connStatus: ConnStatus
+    setConnStatus: (status: ConnStatus) => void
     runConnTest: (apiKey?: string) => void
     apiKey: string
     setApiKey: (key: string) => void

--- a/src/constants/prompts.ts
+++ b/src/constants/prompts.ts
@@ -103,9 +103,6 @@ export const PRO_DEPTH: Record<number, { label: string; desc: string; ideas: num
   4: { label: 'High-Class', desc: 'トップティア', ideas: 10, wait: '30分+',   maxTokens: 8000 },
 };
 
-/** @deprecated use FREE_DEPTH / PRO_DEPTH */
-export const DEPTH = PRO_DEPTH;
-
 export const EXAMPLE_PRODUCTS: Record<string, string[]> = {
   'product':        ['HR人材サービス', 'ATS（採用管理システム）', 'サブスク型SaaS', 'マッチングアプリ'],
   'marketing':      ['ITエンジニア向け転職メディア', 'エンジニア採用支援SaaS', 'B2Bマーケティング支援', 'ECサイト（アパレル）'],

--- a/src/hooks/useAI.ts
+++ b/src/hooks/useAI.ts
@@ -45,13 +45,13 @@ function parseAIJson(raw: string): AIResults {
 
   return JSON.parse(text);
 }
-import { BrainstormForm, AIResults, ChatMessage } from '../types';
+import { BrainstormForm, AIResults, ChatMessage, ConnStatus } from '../types';
 import { callAI, callAIWithKey, testConn, DEFAULT_MODEL_ID, isProMode } from '../constants/models';
 import { FREE_DEPTH, PRO_DEPTH } from '../constants/prompts';
 
 export const useAI = () => {
   const [modelId, setModelId] = useState(DEFAULT_MODEL_ID);
-  const [connStatus, setConnStatus] = useState<{ status: 'idle' | 'testing' | 'ok' | 'error', msg: string }>({ status: 'idle', msg: '' });
+  const [connStatus, setConnStatus] = useState<ConnStatus>({ status: 'idle', msg: '' });
   
   const [loading, setLoading] = useState(false);
   const [results, setResults] = useState<AIResults | null>(null);

--- a/src/hooks/useBrainstormForm.ts
+++ b/src/hooks/useBrainstormForm.ts
@@ -1,5 +1,5 @@
 import { useState, useMemo, useCallback } from 'react';
-import { BrainstormForm } from '../types';
+import { BrainstormForm, AIResults } from '../types';
 import { nextSeed, getSeedByIndex, MOCK_SCENARIOS } from '../constants/mockData';
 import { TYPES, getDeepDiveSuggestions } from '../constants/prompts';
 import { autoN } from '../utils/formatters';
@@ -59,20 +59,15 @@ export const useBrainstormForm = () => {
     return form.projectName.trim() || autoN(form.productService, form.teamGoals);
   }, [form.projectName, form.productService, form.teamGoals]);
 
-  const [seedModelId, setSeedModelId] = useState<string | null>(null);
-  const [seedResults, setSeedResults] = useState<any | null>(null);
-
   const applySeed = useCallback((index?: number) => {
     const s = index !== undefined ? getSeedByIndex(index) : nextSeed();
     const isPro = isProMode(localStorage.getItem('userApiKey') || '');
 
-    setSeedModelId(s.modelId);
     setDep(isPro ? s.dep : Math.min(s.dep, 3));
     setForm(s.form);
-    setSeedResults(s.results);
     setUsedName(s.form.projectName || autoN(s.form.productService, s.form.teamGoals));
 
-    return { modelId: s.modelId, results: s.results };
+    return { modelId: s.modelId, results: s.results as AIResults };
   }, []);
 
   return {
@@ -89,9 +84,5 @@ export const useBrainstormForm = () => {
     getValidProjectName,
     applySeed,
     seedScenarios: MOCK_SCENARIOS,
-    seedModelId,
-    setSeedModelId,
-    seedResults,
-    setSeedResults
   };
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -69,6 +69,11 @@ export interface ChatMessage {
   content: string;
 }
 
+export interface ConnStatus {
+  status: 'idle' | 'testing' | 'ok' | 'error';
+  msg: string;
+}
+
 export interface ModelInfo {
   id: string;
   label: string;

--- a/src/utils/report.ts
+++ b/src/utils/report.ts
@@ -1,5 +1,5 @@
 import { BrainstormForm, AIResults } from '../types';
-import { TYPES, DEPTH } from '../constants/prompts';
+import { TYPES, PRO_DEPTH } from '../constants/prompts';
 import { ll } from './formatters';
 
 export const buildReportMd = (
@@ -19,7 +19,7 @@ export const buildReportMd = (
   md += `- **プロダクト/サービス**: ${form.productService}\n`;
   md += `- **セッション種別**: ${ses}\n`;
   md += `- **タイムライン**: ${tl}\n`;
-  md += `- **分析深度**: ${DEPTH[dep].label}\n`;
+  md += `- **分析深度**: ${PRO_DEPTH[dep]?.label ?? `Lv${dep}`}\n`;
   md += `- **使用モデル**: ${provN} / ${mL}\n`;
   md += `- **生成日時**: ${now}\n\n`;
   


### PR DESCRIPTION
## Summary
- `ConnStatus` 型を types/index.ts に抽出、4箇所のインライン定義を統一
- プロジェクト全体の `any` 型を完全排除（0件）
- deprecated `DEPTH` export を削除、report.ts を `PRO_DEPTH` に移行
- useBrainstormForm から未使用 state（seedModelId/seedResults）を削除
- LogPanel `onImport: any` → `unknown`
- モーダルに `role="dialog"` `aria-modal="true"` `aria-labelledby` を追加

## Test plan
- [x] tsc --noEmit pass
- [x] vite build pass
- [x] `grep -r 'any' src/ --include='*.ts' --include='*.tsx'` = 0 hits
- [ ] Seed投入 → 結果表示が正常であること
- [ ] モーダル（ログ/プレビュー）の開閉が正常であること