### PR TITLE
refactor: マジックナンバー定数化 + ErrorBoundary

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,50 @@
+import { Component, ErrorInfo, ReactNode } from 'react'
+import { T } from '../constants/theme'
+
+interface Props {
+    children: ReactNode
+}
+
+interface State {
+    hasError: boolean
+    error: Error | null
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+    constructor(props: Props) {
+        super(props)
+        this.state = { hasError: false, error: null }
+    }
+
+    static getDerivedStateFromError(error: Error): State {
+        return { hasError: true, error }
+    }
+
+    componentDidCatch(error: Error, info: ErrorInfo) {
+        console.error('ErrorBoundary caught:', error, info.componentStack)
+    }
+
+    render() {
+        if (this.state.hasError) {
+            return (
+                <div className={`${T.page} min-h-screen flex items-center justify-center p-8`}>
+                    <div className={`${T.card} p-8 max-w-lg text-center`}>
+                        <h2 className={`text-lg font-semibold ${T.t1} mb-2`}>
+                            予期しないエラーが発生しました
+                        </h2>
+                        <p className={`text-sm ${T.t3} mb-4`}>
+                            {this.state.error?.message || '不明なエラー'}
+                        </p>
+                        <button
+                            onClick={() => window.location.reload()}
+                            className={`px-4 py-2 rounded-lg text-sm font-medium ${T.btnAccent}`}
+                        >
+                            ページを再読み込み
+                        </button>
+                    </div>
+                </div>
+            )
+        }
+        return this.props.children
+    }
+}

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -1,0 +1,11 @@
+/** ログ保存・インポートの最大件数 */
+export const MAX_LOGS = 200;
+
+/** 会話履歴の最大メッセージ数 */
+export const MAX_HIST = 10;
+
+/** ログ保存デバウンス間隔 (ms) */
+export const SAVE_DEBOUNCE_MS = 300;
+
+/** refine / deepDive のデフォルトトークン上限 */
+export const CHAT_MAX_TOKENS = 4096;

--- a/src/hooks/useAI.ts
+++ b/src/hooks/useAI.ts
@@ -48,6 +48,7 @@ function parseAIJson(raw: string): AIResults {
 import { BrainstormForm, AIResults, ChatMessage, ConnStatus } from '../types';
 import { callAI, callAIWithKey, testConn, DEFAULT_MODEL_ID, isProMode } from '../constants/models';
 import { FREE_DEPTH, PRO_DEPTH } from '../constants/prompts';
+import { MAX_HIST, CHAT_MAX_TOKENS } from '../constants/config';
 
 export const useAI = () => {
   const [modelId, setModelId] = useState(DEFAULT_MODEL_ID);
@@ -269,13 +270,13 @@ JSONのみ回答:
       const msg: ChatMessage = { role: 'user', content: `あなたは戦略コンサルタントです。以下のレビュー・フィードバックに基づき、戦略提案をブラッシュアップしてください。\n\n【前提条件】現状を批判せず、強みを活かした建設的な改善提案に絞る。担当者が実行できる具体案を出す。\n\n【レビュー内容】${reviewText}\n\nMarkdown形式（見出し・箇条書き活用）で回答してください。` };
       const h2 = [...hist, msg];
       const raw = proMode
-        ? await callAIWithKey(apiKey.trim(), modelId, h2, 4096)
-        : await callAI(modelId, h2, 4096);
+        ? await callAIWithKey(apiKey.trim(), modelId, h2, CHAT_MAX_TOKENS)
+        : await callAI(modelId, h2, CHAT_MAX_TOKENS);
 
       const newResults = { ...results, refinement: raw };
       setResults(newResults);
       const newHist = [...h2, { role: 'assistant' as const, content: raw }];
-      setHist(newHist.slice(-10));
+      setHist(newHist.slice(-MAX_HIST));
       setReviewText('');
 
       onSuccess(newResults, reviewText);
@@ -331,8 +332,8 @@ JSONのみ回答:
         content: `あなたは戦略コンサルタントです。以下の事業状況を踏まえ、質問に詳細回答してください。\n\n【事業状況】\n${context}\n\n【前提条件】現状批判ではなく「次の打ち手・改善機会」として建設的に回答すること。担当者（営業・マーケ・経営企画）が実行できる具体策を含めること。\n\n【質問】${q}\n\nMarkdown形式（見出し・テーブル・箇条書き活用）で詳細回答してください。`,
       };
       const raw = proMode
-        ? await callAIWithKey(apiKey.trim(), modelId, [msg], 4096)
-        : await callAI(modelId, [msg], 4096);
+        ? await callAIWithKey(apiKey.trim(), modelId, [msg], CHAT_MAX_TOKENS)
+        : await callAI(modelId, [msg], CHAT_MAX_TOKENS);
 
       setResults(p => p ? ({ ...p, deepDives: [...(p.deepDives || []), { question: q, answer: raw }] }) : p);
     } catch (e: unknown) {

--- a/src/hooks/useLogs.ts
+++ b/src/hooks/useLogs.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef } from 'react';
 import { LogEntry, Settings, BrainstormForm, AIResults } from '../types';
 import { loadLogs, saveLogs, loadSettings, saveSettings } from '../utils/storage';
+import { MAX_LOGS, SAVE_DEBOUNCE_MS } from '../constants/config';
 
 export const useLogs = () => {
   const [logs, setLogs] = useState<LogEntry[]>(() => loadLogs());
@@ -14,7 +15,7 @@ export const useLogs = () => {
       if (!saveLogs(data)) {
         console.warn('localStorage quota exceeded — logs may not be saved');
       }
-    }, 300);
+    }, SAVE_DEBOUNCE_MS);
   }, []);
 
   const updateSettings = useCallback((s: Settings) => {
@@ -35,7 +36,7 @@ export const useLogs = () => {
       ...(stgSettings.logMode === 'all' ? { query: q, results: res } : { results: res })
     };
     
-    const updated = [entry, ...logs].slice(0, 200);
+    const updated = [entry, ...logs].slice(0, MAX_LOGS);
     setLogs(updated);
     debouncedSave(updated);
   }, [logs, stgSettings, debouncedSave]);
@@ -58,7 +59,7 @@ export const useLogs = () => {
     const merged = [...valid, ...logs];
     const unique = [...new Map(merged.map(x => [x.id, x])).values()]
       .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
-      .slice(0, 200);
+      .slice(0, MAX_LOGS);
 
     setLogs(unique);
     if (!saveLogs(unique)) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
+import { ErrorBoundary } from './components/ErrorBoundary'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
-        <App />
+        <ErrorBoundary>
+            <App />
+        </ErrorBoundary>
     </React.StrictMode>,
 )


### PR DESCRIPTION
## Summary
- `src/constants/config.ts` 新設: MAX_LOGS, MAX_HIST, SAVE_DEBOUNCE_MS, CHAT_MAX_TOKENS
- useLogs.ts / useAI.ts のハードコード数値を定数に置換
- `ErrorBoundary` コンポーネント追加、main.tsx でApp全体をラップ
- ランタイムエラー発生時にユーザーに再読み込みUIを表示

## Test plan
- [x] tsc --noEmit pass
- [x] vite build pass
- [ ] ログ保存/インポートが正常であること
- [ ] refine/deepDive のトークン制限が正常動作すること