### PR TITLE
feat: Claude Code 環境設定 Phase 2

### DIFF
--- a/.claude/hooks/protect-main.sh
+++ b/.claude/hooks/protect-main.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# main ブランチへの直接 push をブロックする PreToolUse Hook
+# exit 2 = ブロック, exit 0 = 許可
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if echo "$COMMAND" | grep -qE 'git push.*(origin )?(main|master)'; then
+  echo "main への直接 push はブロックされました。ブランチを作成して PR 経由でマージしてください。" >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "preToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./.claude/hooks/protect-main.sh"
+          }
+        ]
+      }
+    ],
     "postToolUse": [
       {
         "matcher": "Write|Edit",
@@ -7,6 +18,17 @@
           {
             "type": "command",
             "command": "npx tsc --noEmit --pretty 2>&1 | head -20"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "osascript -e 'display notification \"入力待ちです\" with title \"Claude Code\"'"
           }
         ]
       }

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -1,0 +1,20 @@
+# Fix Issue Skill
+
+GitHub Issue を読み取り、ブランチ作成から PR 作成まで一括で実行する。
+
+## 手順
+
+1. `gh issue view $0` で Issue の内容を確認する
+2. Issue の内容に基づいて `feature/issue-$0-<短い説明>` ブランチを作成する
+3. 関連するソースコードを調査し、実装方針を3行で説明する
+4. ユーザーの承認を得てから実装を開始する
+5. 実装後、`npx tsc --noEmit` と `npm test` で検証する
+6. conventional commit でコミットする（メッセージに `close #$0` を含める）
+7. ブランチを push し、`gh pr create` で PR を作成する
+
+## ルール
+
+- 実装前に方針を確認する（Wrong Approach 防止）
+- 2回修正して解決しない場合は原因分析を報告する
+- スコープが大きい場合は分割を提案する
+- main への直接 push は禁止

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ npm-debug.log*
 # Cache
 .cache/
 .eslintcache
+
+# Claude Code (個人設定)
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

Insights レポートの残り提案を実装。Phase 1（#57）の設定に加え、決定的なガードレールとワークフロー効率化を追加。

### 追加内容

| 追加 | ファイル | 解決するフリクション |
|------|---------|-------------------|
| **main push ブロック** | `.claude/hooks/protect-main.sh` | 無断デプロイ（PreToolUse Hook, exit 2 でブロック） |
| **デスクトップ通知** | `.claude/settings.json` | 長時間待機時の見落とし（Notification Hook） |
| **/fix-issue スキル** | `.claude/skills/fix-issue/` | Issue 駆動開発の定型化 |
| **.gitignore 更新** | `.gitignore` | settings.local.json の誤コミット防止 |

### Phase 1 との関係

- Phase 1: CLAUDE.md ルール、/push、/review、型チェック Hook
- Phase 2: 決定的ガード（main push ブロック）、通知、Issue ワークフロー

## Test plan

- [ ] main ブランチで `git push origin main` が Hook によりブロックされることを確認
- [ ] 他ブランチでの push はブロックされないことを確認
- [ ] Claude が入力待ち時に macOS 通知が表示されることを確認
- [ ] `/fix-issue 123` でスキルが正しく発火することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * mainブランチへの直接プッシュをブロックする保護機能を追加
  * Fix Issueスキルの新しいドキュメントを追加

* **Chores**
  * Claude環境設定ファイルとgitignoreを更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->