### PR TITLE
feat: 初回訪問者にヘルプモーダルを自動表示

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -85,7 +85,7 @@ export default function App() {
             if (e.key === 'Escape') {
                 if (showLogs) setShowLogs(false)
                 else if (showPrev) setShowPrev(false)
-                else if (showHelp) setShowHelp(false)
+                else if (showHelp) { localStorage.setItem('ai-brainstorm-visited', '1'); setShowHelp(false) }
                 else if (showCfg) setShowCfg(false)
             }
         }


### PR DESCRIPTION
## Summary
- 初回訪問時にヘルプモーダル（使い方ガイド）を自動表示
- localStorageで訪問フラグを管理し、2回目以降は非表示
- React StrictModeの二重マウントに対応（フラグ書き込みはモーダル閉じ時に実行）

## Test plan
- [ ] シークレットウィンドウで初回アクセス → ヘルプモーダルが表示される
- [ ] モーダルを閉じてリロード → ヘルプモーダルが表示されない
- [ ] ヘッダーの「?」ボタンから手動でヘルプを開ける

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * ヘルプモーダルの表示状態がユーザーの操作に応じて永続化されるようになりました。モーダルを閉じる（ボタンやEsc）とその状態が保存され、次回訪問時に自動で非表示になります。必要時は引き続きヘルプを開けます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->