### PR TITLE
fix: 接続テスト表示をシンプル化

### DIFF
--- a/src/hooks/useAI.ts
+++ b/src/hooks/useAI.ts
@@ -21,8 +21,8 @@ export const useAI = () => {
   const runConnTest = useCallback(async (apiKey = '') => {
     setConnStatus({ status: 'testing', msg: '' });
     try {
-      const model = await testConn(modelId, apiKey);
-      setConnStatus({ status: 'ok', msg: `OK: ${model}` });
+      await testConn(modelId, apiKey);
+      setConnStatus({ status: 'ok', msg: 'OK' });
     } catch (e: unknown) {
       setConnStatus({ status: 'error', msg: e instanceof Error ? e.message : String(e) });
     }


### PR DESCRIPTION
## Summary
- 接続テスト成功時の表示を `OK: gpt-5-nano-2025-08-07` → `OK` に変更
- APIレスポンスの日付付きスナップショット名はユーザーに不要な情報のため非表示化

## Test plan
- [ ] 接続テスト成功時に「OK」のみ表示されること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 接続テストの成功メッセージをシンプル化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->