### PR TITLE
fix: Vite dev proxyの421エラー修正

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig(({ mode }) => {
         '/api/openai': {
           target: 'https://api.openai.com',
           changeOrigin: true,
-          rewrite: (path) => path.replace(/^\/api\/openai/, ''),
+          rewrite: (path) => path.replace(/^\/api\/openai/, '/v1/chat/completions'),
           configure: (proxy) => {
             proxy.on('proxyReq', (proxyReq) => {
               if (env.OPENAI_API_KEY) proxyReq.setHeader('Authorization', `Bearer ${env.OPENAI_API_KEY}`)


### PR DESCRIPTION
## Summary
- 開発環境でOpenAI API呼び出し時に421 (Misdirected Request)が発生する問題を修正
- Vite proxy rewriteが`/api/openai` → `/`（ルート）に変換していたため、OpenAIのWelcomeページに到達していた
- `/api/openai` → `/v1/chat/completions` に変換するよう修正

## Test plan
- [x] `npm run build` 成功
- [ ] `npm run dev` でローカル動作確認（AI生成が421なく動作すること）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チューナ**
  * OpenAIエンドポイントへのAPIリクエストパスの処理を更新しました。これにより、プロキシの書き換えロジックが改善され、より正確なリクエストルーティングが実現されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->