### PR TITLE
fix: Seed並び順を人材/HR/マーケティング優先に再調整

### DIFF
--- a/src/constants/mockData.ts
+++ b/src/constants/mockData.ts
@@ -9,8 +9,8 @@ export const MOCK_SCENARIOS: MockScenario[] = [
       projectName: 'Nimbus-447',
       productService: 'ITエンジニア特化の人材紹介エージェント（CA 15名・年間成約300件）',
       teamGoals: '成約件数+40%・ハイスキル層（年収600万+）比率20%・CA一人当たり生産性1.5倍',
-      sessionType: 'other',
-      customSession: 'IT人材紹介 事業戦略',
+      sessionType: 'ops',
+      customSession: '',
       issues: [
         { text: 'ハイスキル層の獲得難', detail: '登録者の70%がジュニア・レガシー系、ハイスキル層の登録比率8%で成約単価が低い', sub: ['エンジニアのエージェント不信が強く登録障壁が高い', '技術系コミュニティ・SNSへのリーチがない'] },
         { text: '直接採用・競合増加で差別化が困難', detail: 'LinkedIn等での直接採用が3年で2倍増、大手との価格競争に巻き込まれている', sub: ['差別化ポイントが「担当者の質」のみで再現性・スケールなし', 'フィー値下げ圧力でLTVが低下'] },

--- a/src/constants/prompts.ts
+++ b/src/constants/prompts.ts
@@ -1,5 +1,4 @@
 export const TYPES: Record<string, string> = {
-  'other': '経営戦略・その他',
   'ops': '営業・業務オペレーション',
   'marketing': 'マーケティング・集客',
   'growth': 'グロース・収益拡大',
@@ -7,6 +6,7 @@ export const TYPES: Record<string, string> = {
   'product': 'サービス・事業改善',
   'dx': 'デジタル化・業務効率化',
   'innovation': '新規事業・イノベーション',
+  'other': '経営戦略・その他',
   'design-system': 'ブランド・UI統一',
 };
 


### PR DESCRIPTION
## Summary
- TYPES順を `ops → marketing → growth` 先頭に変更
- 「IT人材紹介 事業戦略」の sessionType を `other` → `ops` に変更し人材系グループに統合
- 人材系5件が上位3グループの先頭に集約