### PR TITLE
fix: レイアウトプリセットアイコンの左右を修正

### DIFF
--- a/src/components/layout/HeaderBar.tsx
+++ b/src/components/layout/HeaderBar.tsx
@@ -153,9 +153,9 @@ export const HeaderBar: React.FC<HeaderBarProps> = ({
                 </div>
                 <div className='hidden lg:flex items-center gap-0.5 p-0.5 rounded-lg border border-slate-200 dark:border-slate-700/60 bg-slate-50 dark:bg-slate-800/40'>
                     {([
-                        { key: 'leftFocus', icon: PanelLeftClose, title: '左メイン (70:30)' },
+                        { key: 'leftFocus', icon: PanelRightClose, title: '左メイン (70:30)' },
                         { key: 'equal', icon: Columns2, title: '均等 (50:50)' },
-                        { key: 'rightFocus', icon: PanelRightClose, title: '右メイン (30:70)' },
+                        { key: 'rightFocus', icon: PanelLeftClose, title: '右メイン (30:70)' },
                     ] as const).map(({ key, icon: Icon, title }) => (
                         <button
                             key={key}


### PR DESCRIPTION
## Summary
- 左メイン(70:30)に `PanelLeftClose`（左を閉じる見た目）が使われていたのを `PanelRightClose` に入れ替え
- 右メインも同様に修正し、アイコンの面積比がレイアウト比率と一致するように

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * レイアウトプリセットのアイコン表示が修正されました。左メインプリセットと右メインプリセットで、表示されるアイコンが正しく対応するように調整されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->