### PR TITLE
fix: PR #89 レビュー課題対応

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# prettier による全ファイルフォーマット (PR #89)
+edd062e98bfac5b7482eb8cb9fd12df22179bb3e

--- a/src/__tests__/costTracker.test.ts
+++ b/src/__tests__/costTracker.test.ts
@@ -7,6 +7,7 @@ import {
   resetCycle,
   checkBudget,
   getDailyTotal,
+  _resetAll,
 } from '../utils/costTracker';
 import { DAILY_COST_KEY } from '../constants/config';
 
@@ -47,8 +48,9 @@ describe('calculateCostJpy', () => {
 });
 
 describe('addUsage / getSessionTotal / getCycleTotal', () => {
-  // costTracker はモジュールレベル変数を使うため、
-  // テスト間で累積する点に注意（resetCycle でサイクルのみリセット可能）
+  beforeEach(() => {
+    _resetAll();
+  });
 
   it('addUsage でセッション・サイクル累計が増加する', () => {
     const before = getSessionTotal();
@@ -70,7 +72,7 @@ describe('addUsage / getSessionTotal / getCycleTotal', () => {
 
 describe('checkBudget', () => {
   beforeEach(() => {
-    resetCycle();
+    _resetAll();
     localStorageMock.clear();
   });
 
@@ -91,7 +93,6 @@ describe('checkBudget', () => {
   });
 
   it('予算内なら null を返す', () => {
-    resetCycle();
     const warning = checkBudget(0.05, true);
     expect(warning).toBeNull();
   });
@@ -100,7 +101,6 @@ describe('checkBudget', () => {
     // localStorage に高額の日次累計をセット
     const today = new Date().toISOString().slice(0, 10);
     localStorageMock.setItem(DAILY_COST_KEY, JSON.stringify({ date: today, total: 35 }));
-    resetCycle();
     const warning = checkBudget(0.01, false);
     expect(warning).not.toBeNull();
     expect(warning!.severity).toBe('info');

--- a/src/utils/costTracker.ts
+++ b/src/utils/costTracker.ts
@@ -56,6 +56,12 @@ export function resetCycle(): void {
   cycleTotal = 0;
 }
 
+/** テスト用: セッション・サイクル両方リセット */
+export function _resetAll(): void {
+  sessionTotal = 0;
+  cycleTotal = 0;
+}
+
 // ── localStorage 日次累計 ──
 interface DailyRecord {
   date: string;


### PR DESCRIPTION
## Summary
- `.git-blame-ignore-revs` 追加（prettier 整形コミットを git blame から除外）
- costTracker テストの分離性改善: `_resetAll()` 関数追加、各 describe で beforeEach リセット

## Test plan
- [x] `npm test` — 37テスト全通過
- [x] `npm run build` — ビルド成功

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **チョア (Chores)**
  * テストインフラストラクチャの更新と初期化機能の改善

<!-- end of auto-generated comment: release notes by coderabbit.ai -->