### PR TITLE
fix: E2E テストのレビュー指摘対応

### DIFF
--- a/e2e/dark-mode.spec.ts
+++ b/e2e/dark-mode.spec.ts
@@ -47,7 +47,6 @@ test.describe('ダークモード', () => {
       while ((node = walker.nextNode() as Element | null)) {
         const style = getComputedStyle(node);
         const color = style.color;
-        const bg = style.backgroundColor;
 
         // 不可視要素はスキップ
         if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0')
@@ -89,7 +88,8 @@ test.describe('ダークモード', () => {
     ).toHaveLength(0);
   });
 
-  test('ダークモード: スクリーンショット', async ({ page }) => {
+  // スクリーンショットは OS フォント差異があるため CI ではスキップ
+  test('ダークモード: スクリーンショット', { tag: '@visual' }, async ({ page }) => {
     await page.goto('/');
 
     const html = page.locator('html');
@@ -105,7 +105,7 @@ test.describe('ダークモード', () => {
     });
   });
 
-  test('ライトモード: スクリーンショット', async ({ page }) => {
+  test('ライトモード: スクリーンショット', { tag: '@visual' }, async ({ page }) => {
     await page.goto('/');
 
     const html = page.locator('html');

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -35,10 +35,10 @@ test.describe('スモークテスト', () => {
     const seedBtn = page.getByRole('button', { name: 'Seedデータ選択' });
     await seedBtn.hover();
     // ドロップダウンが表示される
-    const dropdown = page.locator('[data-tour="seed"] + div, .absolute.right-0.top-full');
-    await expect(dropdown.first()).toBeVisible({ timeout: 3000 });
+    const dropdown = page.getByTestId('seed-dropdown');
+    await expect(dropdown).toBeVisible({ timeout: 3000 });
     // 最初のシナリオをクリック
-    await dropdown.first().locator('button').first().click();
+    await dropdown.locator('button').first().click();
     // フォームにデータが入る
     const serviceInput = page.getByPlaceholder('プロダクト / サービスカテゴリ名');
     await expect(serviceInput).not.toHaveValue('');

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   outputDir: './e2e/test-results',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
+  grepInvert: process.env.CI ? /@visual/ : undefined,
   retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',

--- a/src/components/layout/HeaderBar.tsx
+++ b/src/components/layout/HeaderBar.tsx
@@ -192,7 +192,10 @@ export const HeaderBar: React.FC<HeaderBarProps> = ({
             Seed
           </button>
           {seedOpen && (
-            <div className="absolute right-0 top-full mt-1 w-80 max-h-[28rem] overflow-y-auto rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-lg z-50">
+            <div
+              data-testid="seed-dropdown"
+              className="absolute right-0 top-full mt-1 w-80 max-h-[28rem] overflow-y-auto rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-lg z-50"
+            >
               {groupedSeeds.map((g) => (
                 <div key={g.type}>
                   <div


### PR DESCRIPTION
## Summary
PR #92 のレビュー指摘3件を修正

- **スクリーンショット darwin 固定問題**: `@visual` タグを付与し、CI では `grepInvert` で自動スキップ
- **Seed セレクタ脆弱性**: `data-testid="seed-dropdown"` を HeaderBar に追加し、テスト側を `getByTestId` に変更
- **未使用変数**: dark-mode テストの `bg` 変数を削除

## Test plan
- [x] `npx playwright test` 全10テスト pass
- [x] `npm test` 全53テスト pass
- [x] `npm run build` 成功

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * テストセレクタを改善し、テストの堅牢性を向上
  * CI環境でビジュアルテストを自動スキップするように設定
  * テストタグを追加してテストの分類・管理を強化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->