### PR TITLE
fix: API データ送信に関する注意書きを追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -409,6 +409,9 @@ export default function App() {
                       )}
                     </span>
                   </button>
+                  <p className={`text-[10px] ${T.t3} text-center mt-1`}>
+                    入力内容は OpenAI API に送信されます。個人名・機密情報の入力はお控えください
+                  </p>
                 </div>
               </div>
             </div>

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -207,6 +207,12 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
           </p>
         </div>
 
+        {/* API 利用に関する注意 */}
+        <p className={`text-[10px] leading-relaxed ${T.t3}`}>
+          入力内容は OpenAI API に送信されます。個人名・機密情報の入力はお控えください。API
+          経由のデータはモデル学習には使用されません。
+        </p>
+
         {/* Reset Data */}
         <div className={`pt-3 mt-1 border-t ${T.div} flex justify-end`}>
           <button


### PR DESCRIPTION
## Summary
- SettingsModal（接続テスト下部）に注意文を追加
- 送信ボタン直下に注意文を追加
- 内容: 「入力内容は OpenAI API に送信されます。個人名・機密情報の入力はお控えください」

## 設置場所
1. **SettingsModal**: 接続テストとデータ初期化の間。API経由のデータがモデル学習に使用されない旨も記載
2. **送信ボタン下**: 1行の簡潔な注意文

## Test plan
- [x] `npm test` 全53テスト pass
- [x] `npm run build` 成功

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * OpenAI APIへのデータ送信に関する注記をアプリケーション内に追加しました。個人情報や機密データを入力しないようユーザーに通知し、APIを通じたデータが機械学習の訓練に使用されないことを明示します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->