### PR TITLE
fix: デスクトップ大画面のレスポンシブ改善

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -350,7 +350,7 @@ export default function App() {
 
   return (
     <div className={T.page}>
-      <div className="max-w-screen-2xl mx-auto px-4 py-4 md:px-8 md:py-6">
+      <div className="max-w-[1920px] mx-auto px-4 py-4 md:px-6 md:py-6 xl:px-10">
         {/* ── Header ── */}
         <HeaderBar
           proMode={proMode}
@@ -403,7 +403,7 @@ export default function App() {
             className="w-full lg:sticky lg:top-4 lg:shrink-0 lg:pr-2"
             style={{ flex: `0 0 ${ratio}%` }}
           >
-            <div className={`${T.card} p-4`}>
+            <div className={`${T.card} p-4 xl:p-5`}>
               <ProjectForm
                 form={form}
                 setForm={setForm}

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -9,9 +9,9 @@ export const T = {
   t2: 'text-slate-600 dark:text-slate-400',
   t3: 'text-slate-400 dark:text-slate-400',
   // Inputs
-  inp: 'w-full px-3 py-2 rounded-lg bg-slate-50 dark:bg-slate-800/60 border border-slate-200 dark:border-slate-700/60 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 text-base md:text-sm focus:outline-none focus:border-brand-light dark:focus:border-brand-light transition',
+  inp: 'w-full px-3 py-2 rounded-lg bg-slate-50 dark:bg-slate-800/60 border border-slate-200 dark:border-slate-700/60 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 text-base md:text-sm xl:text-base focus:outline-none focus:border-brand-light dark:focus:border-brand-light transition',
   inpSm:
-    'w-full px-2.5 py-1.5 rounded-lg bg-slate-50 dark:bg-slate-800/60 border border-slate-200 dark:border-slate-700/60 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 text-base md:text-xs focus:outline-none focus:border-brand-light dark:focus:border-brand-light transition',
+    'w-full px-2.5 py-1.5 rounded-lg bg-slate-50 dark:bg-slate-800/60 border border-slate-200 dark:border-slate-700/60 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 text-base md:text-xs xl:text-sm focus:outline-none focus:border-brand-light dark:focus:border-brand-light transition',
   // Buttons
   btnGhost:
     'bg-slate-100 dark:bg-slate-800/60 border border-slate-200 dark:border-slate-700/60 text-slate-600 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-700/60 transition',

--- a/src/hooks/usePanelResize.ts
+++ b/src/hooks/usePanelResize.ts
@@ -3,7 +3,7 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 const STORAGE_KEY = 'panelRatio';
 const MIN = 20;
 const MAX = 80;
-const DEFAULT = 40;
+const DEFAULT = 35;
 
 export const PRESETS = {
   leftFocus: 70,


### PR DESCRIPTION
## Summary
- max-width を 1536px → 1920px に拡大（大画面での余白を削減）
- xl (1280px+) 以上でパディング・入力テキストサイズを拡大
- パネルデフォルト比率を 40:60 → 35:65 に変更（結果側を広く表示）

## Test plan
- [x] ビルド成功
- [ ] 1920px以上のディスプレイで余白が改善されていることを確認
- [ ] xl ブレークポイントでテキストサイズが適切であることを確認
- [ ] 既存のモバイル/タブレット表示に影響がないことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * 大型ディスプレイでのレスポンシブレイアウトとスペーシングが改善されました。
  * 入力フィールドのテキストサイズ表示が各画面サイズで最適化されました。
  * パネル分割の初期比率を調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->